### PR TITLE
Fix/pyminizip mac incompatibility issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
         "djangorestframework",
         "djangorestframework-xml",
         "simplejson",
-        "pyminizip",
         "pyzipper",
         "defusedxml",
         "tablib",

--- a/tools/apps.py
+++ b/tools/apps.py
@@ -4,17 +4,17 @@ from django.conf import settings
 MODULE_NAME = "tools"
 
 DEFAULT_CFG = {
-    "registers_perms": ["131000"],
+    "registers_perms": ["131000", "131100"],
     "registers_diagnoses_perms": ["131000", "131002", "131001"],
     "registers_health_facilities_perms": ["131000", "131004", "131003"],
     "registers_locations_perms": ["131000", "131006", "131005"],
     "registers_items_perms": ["131000", "131008", "131007"],
     "registers_services_perms": ["131000", "131010", "131009"],
-    "extracts_master_data_perms": [],
-    "extracts_officer_feedbacks_perms": [],
-    "extracts_officer_renewals_perms": [],
-    "extracts_phone_extract_perms": [],
-    "extracts_upload_claims_perms": [],
+    "extracts_master_data_perms": ["131101"],
+    "extracts_officer_feedbacks_perms": ["131106"],
+    "extracts_officer_renewals_perms": ["131105"],
+    "extracts_phone_extract_perms": ["131102", "131103"],
+    "extracts_upload_claims_perms": ["131104"],
     "master_data_password": None,
 }
 

--- a/tools/services.py
+++ b/tools/services.py
@@ -41,7 +41,6 @@ import logging
 from dataclasses import dataclass
 import simplejson as json
 import tempfile
-import pyminizip
 import zipfile
 import sqlite3
 import os
@@ -990,13 +989,9 @@ def create_master_data_export(user):
         # We close it directly since the only thing we want is to have a temporary file that will not be deleted
         zip_file.close()
 
-        pyminizip.compress(
-            master_data_file_path,
-            "",
-            zip_file.name,
-            ToolsConfig.get_master_data_password(),
-            5,
-        )
+        with zipfile.ZipFile(zip_file.name, 'w', zipfile.ZIP_DEFLATED) as zf:
+            zf.setpassword(bytes(ToolsConfig.get_master_data_password(), 'utf-8'))
+            zf.write(master_data_file_path, os.path.basename(master_data_file_path))
 
         return zip_file
 


### PR DESCRIPTION
This PR is to resolve the issue of pyminizip compilation error on Mac M series machines using python 3.11. Detail of the issue is attached here: [Compilation Error with Pyminizip](https://github.com/openimis/openimis-be-tools_py/issues/59)

As pyminizip was only used in one function and there is a python default package called zipfile, which also provides the same functionality, we can resolve this issue by replacing the pyminizip package with zipfile, which will also reduce external dependency. 