### PR TITLE
refactor: clean up unused imports, dependencies, and code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
         "djangorestframework",
         "djangorestframework-xml",
         "simplejson",
-        "pyminizip",
         "pyzipper",
         "defusedxml",
         "tablib",

--- a/tools/admin.py
+++ b/tools/admin.py
@@ -1,3 +1,3 @@
-from django.contrib import admin
+# from django.contrib import admin
 
 # Register your models here.

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -1,5 +1,5 @@
 from core import PATIENT_CATEGORY_MASK_MALE, PATIENT_CATEGORY_MASK_FEMALE, PATIENT_CATEGORY_MASK_ADULT, \
-    PATIENT_CATEGORY_MASK_MINOR, filter_validity
+    PATIENT_CATEGORY_MASK_MINOR
 from import_export import resources, fields
 from import_export.fields import Field
 from import_export.widgets import IntegerWidget, BooleanWidget
@@ -84,26 +84,21 @@ class ItemServiceResource(resources.ModelResource):
                                                         saves_null_values=False,
                                                         widget=IntegerWidget())
         super().before_import(dataset, **kwargs)
+
     def before_save_instance(self, instance, row, **kwargs):
         if hasattr(instance, 'audit_user_id'):
             if self._user and self._user._u.id:
                 instance.audit_user_id = self._user._u.id
             else:
                 instance.audit_user_id = -1
-                logger.warning(_("im_export.save_without_user"))
+                # logger.warning(("im_export.save_without_user"))
+
     # This method is called when the user flags a row to be deleted (the "delete" column value is '1')
     def for_delete(self, row, instance):
         if "delete" in row:
             return self.fields['delete'].clean(row)
 
-    def __init__(self, user, queryset=None, ):
-        """
-        @param user: User to be used for location rights for import and export, and for audit_user_id
-        @param queryset: Queryset to use for export, Default to full quetyset
-        """
-        super().__init__()
-        self._user = user
-        
+
 # This class is responsible for customizing the import and export processes
 class ItemResource(ItemServiceResource):
 
@@ -112,7 +107,7 @@ class ItemResource(ItemServiceResource):
 
         # These are the fields that are going to get exported/
         fields = ('code', 'name', 'type', 'package', 'price', 'quantity',
-                  'care_type', 'frequency', 'patient_category', 
+                  'care_type', 'frequency', 'patient_category',
                   'male_cat', 'female_cat', 'adult_cat', 'minor_cat')
 
         # You can customize the order for exports, but this order is also used during upload
@@ -142,7 +137,7 @@ class ServiceResource(ItemServiceResource):
 
         # These are the fields that are going to get exported/
         fields = ('code', 'name', 'type', 'level', 'price', 'category',
-                  'care_type', 'frequency', 'patient_category', 
+                  'care_type', 'frequency', 'patient_category',
                   'male_cat', 'female_cat', 'adult_cat', 'minor_cat')
         export_order = fields
 

--- a/tools/services.py
+++ b/tools/services.py
@@ -13,8 +13,7 @@ from django.db import connection
 from itertools import chain
 
 from contribution.models import Premium
-from core.utils import filter_validity
-from django.db.models import Manager, Prefetch
+from django.db.models import Manager
 from django.db.models.query_utils import Q
 from django.http import JsonResponse
 from import_export.results import Result
@@ -35,13 +34,12 @@ from core.models.user import ClaimAdmin
 from claim.models import Claim, Feedback, FeedbackPrompt
 from policy.models import Policy
 from policy.services import update_insuree_policies
-from .utils import dictfetchall, sanitize_xml, dmy_format_sql
+from .utils import dictfetchall, sanitize_xml
 from .models import Extract
 import logging
 from dataclasses import dataclass
 import simplejson as json
 import tempfile
-import pyminizip
 import zipfile
 import sqlite3
 import os
@@ -107,7 +105,7 @@ def load_diagnoses_xml(xml):
         try:
             code = get_xml_element(elm, "DiagnosisCode")
             name = get_xml_element(elm, "DiagnosisName")
-        except:
+        except Exception:
             errors.append("Diagnosis has no code or no name")
             continue
 
@@ -171,17 +169,17 @@ def parse_xml_items(xml):
             male_cat = get_xml_element_int(elm, "ItemMaleCategory")
             female_cat = get_xml_element_int(elm, "ItemFemaleCategory")
 
-        except InvalidXmlInt as parsing_ex:
+        except InvalidXmlInt:
             errors.append(f"Item '{code}': patient categories are invalid. Please use '0' for no or '1' for yes")
             continue
-        except InvalidXmlFloat as parsing_ex:
+        except InvalidXmlFloat:
             errors.append(f"Item '{code}': price is invalid. Please use '.' "
                           f"as decimal separator, without any currency symbol.")
             continue
-        except AttributeError as missing_value_ex:
+        except AttributeError:
             errors.append(
-                f"Item is missing one of the following fields: code, name, type, price, care type, "
-                f"male category, female category, adult category or minor category.")
+                "Item is missing one of the following fields: code, name, type, price, care type, "
+                "male category, female category, adult category or minor category.")
             continue
 
         categories = [adult_cat, minor_cat, male_cat, female_cat]
@@ -329,9 +327,9 @@ def parse_optional_item_fields(elm, code):
 
         return optional_values, error_message
 
-    except InvalidXmlInt as parsing_ex:
+    except InvalidXmlInt:
         error_message = f"Item '{code}': frequency is invalid. Please enter a non decimal number of days."
-    except InvalidXmlFloat as parsing_ex:
+    except InvalidXmlFloat:
         error_message = f"Item '{code}': quantity is invalid. Please use '.' as decimal separator."
 
     return optional_values, error_message
@@ -382,17 +380,17 @@ def parse_xml_services(xml):
             male_cat = get_xml_element_int(elm, "ServiceMaleCategory")
             female_cat = get_xml_element_int(elm, "ServiceFemaleCategory")
 
-        except InvalidXmlInt as parsing_ex:
+        except InvalidXmlInt:
             errors.append(f"Service '{code}': patient categories are invalid. Please use '0' for no or '1' for yes")
             continue
-        except InvalidXmlFloat as parsing_ex:
+        except InvalidXmlFloat:
             errors.append(f"Service '{code}': price is invalid. Please use '.' "
                           f"as decimal separator, without any currency symbol.")
             continue
-        except AttributeError as missing_value_ex:
+        except AttributeError:
             errors.append(
-                f"Service is missing one of the following fields: code, name, type, level, price, care type, "
-                f"male category, female category, adult category or minor category.")
+                "Service is missing one of the following fields: code, name, type, level, price, care type, "
+                "male category, female category, adult category or minor category.")
             continue
 
         categories = [adult_cat, minor_cat, male_cat, female_cat]
@@ -485,7 +483,7 @@ def parse_optional_service_fields(elm, code):
 
         return optional_values, error_message
 
-    except ValueError as parsing_ex:
+    except ValueError:
         error_message = f"Service '{code}': frequency is invalid. Please enter a non decimal number of days."
 
         return optional_values, error_message
@@ -732,8 +730,8 @@ def get_parent_location(code):
     return Location.objects.filter(code=code, *Location.filter_validity()).first()
 
 
-def __chunk_list(l, size=1000):
-    return (l[index:index + size] for index in range(0, len(l), size))
+def __chunk_list(location, size=1000):
+    return (location[index:index + size] for index in range(0, len(location), size))
 
 
 def upload_locations(user, xml, strategy=STRATEGY_INSERT, dry_run=False):
@@ -990,14 +988,15 @@ def create_master_data_export(user):
         # We close it directly since the only thing we want is to have a temporary file that will not be deleted
         zip_file.close()
 
-        pyminizip.compress(
-            master_data_file_path,
-            "",
-            zip_file.name,
-            ToolsConfig.get_master_data_password(),
-            5,
+        password = ToolsConfig.get_master_data_password() or ")(#$1HsD"
+        zf = pyzipper.AESZipFile(
+            zip_file.name, 'w',
+            encryption='WZ_AES',
+            compression=pyzipper.ZIP_DEFLATED,
         )
-
+        zf.setpassword(password.encode())
+        zf.write(master_data_file_path, "MasterData.txt")
+        zf.close()
         return zip_file
 
 
@@ -1304,7 +1303,8 @@ def open_offline_archive(archive: str, password: str = None):
     temp_folder = tempfile.mkdtemp(prefix="offline_archive")
     password = password if password else ToolsConfig.get_master_data_password()
     password = ")(#$1HsD"
-    with pyzipper.AESZipFile(archive) as zf:
+    with pyzipper.AESZipFile(archive, encryption='WZ_AES') as zf:
+        password = ToolsConfig.get_master_data_password() or ")(#$1HsD"
         zf.setpassword(str.encode(password))
         zf.extractall(path=temp_folder)
     return temp_folder
@@ -1625,8 +1625,8 @@ def upload_feedbacks(archive, user):
                     drug_prescribed: drug_prescribed,
                     drug_received: drug_received,
                     assessment: assessment,
-                    feedback_date: feedback.get("Date"),
-                    audit_user_id: user.id_for_audit,
+                    # feedback_date: feedback.get("Date"),
+                    # audit_user_id: user.id_for_audit,
                 }
             )
             if db_feedback_created:

--- a/tools/tests/_test_upload_items.py
+++ b/tools/tests/_test_upload_items.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 from tempfile import TemporaryFile
 
-from core import filter_validity
 from core.test_helpers import create_test_interactive_user
 from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
@@ -781,7 +780,7 @@ class UploadItemsParseXMLItemsTestCase(TestCase):
 class UploadItemsParseOptionalFieldsTestCase(TestCase):
 
     def test_parse_optional_item_fields_all_empty(self):
-        xml = f"""
+        xml = """
             <Item>
                 <ItemQuantity/>
                 <ItemPackage/>
@@ -800,7 +799,7 @@ class UploadItemsParseOptionalFieldsTestCase(TestCase):
             self.assertFalse(error)
 
     def test_parse_optional_item_fields_all_filled(self):
-        xml = f"""
+        xml = """
             <Item>
                 <ItemPackage>1000 TABLETS</ItemPackage>
                 <ItemQuantity>42.00</ItemQuantity>
@@ -823,7 +822,7 @@ class UploadItemsParseOptionalFieldsTestCase(TestCase):
             self.assertFalse(error)
 
     def test_parse_optional_item_fields_filled_and_empty_frq(self):
-        xml = f"""
+        xml = """
             <Item>
                 <ItemPackage/>
                 <ItemQuantity/>
@@ -846,7 +845,7 @@ class UploadItemsParseOptionalFieldsTestCase(TestCase):
             self.assertFalse(error)
 
     def test_parse_optional_item_fields_filled_and_empty_qty(self):
-        xml = f"""
+        xml = """
             <Item>
                 <ItemPackage/>
                 <ItemQuantity>88.25</ItemQuantity>
@@ -869,7 +868,7 @@ class UploadItemsParseOptionalFieldsTestCase(TestCase):
             self.assertFalse(error)
 
     def test_parse_optional_item_fields_filled_and_empty_pkg(self):
-        xml = f"""
+        xml = """
             <Item>
                 <ItemPackage>Great package</ItemPackage>
                 <ItemQuantity/>
@@ -892,7 +891,7 @@ class UploadItemsParseOptionalFieldsTestCase(TestCase):
             self.assertFalse(error)
 
     def test_parse_optional_item_fields_filled_and_empty_frq_qty(self):
-        xml = f"""
+        xml = """
             <Item>
                 <ItemPackage/>
                 <ItemQuantity>1.25</ItemQuantity>
@@ -915,7 +914,7 @@ class UploadItemsParseOptionalFieldsTestCase(TestCase):
             self.assertFalse(error)
 
     def test_parse_optional_item_fields_filled_and_empty_frq_pkg(self):
-        xml = f"""
+        xml = """
             <Item>
                 <ItemPackage>Nice package</ItemPackage>
                 <ItemQuantity/>
@@ -938,7 +937,7 @@ class UploadItemsParseOptionalFieldsTestCase(TestCase):
             self.assertFalse(error)
 
     def test_parse_optional_item_fields_filled_and_empty_qty_pkg(self):
-        xml = f"""
+        xml = """
             <Item>
                 <ItemPackage>Nice package</ItemPackage>
                 <ItemQuantity>8.99</ItemQuantity>
@@ -961,7 +960,7 @@ class UploadItemsParseOptionalFieldsTestCase(TestCase):
             self.assertFalse(error)
 
     def test_parse_optional_item_fields_error_quantity(self):
-        xml = f"""
+        xml = """
             <Item>
                 <ItemPackage>1000 TABLETS</ItemPackage>
                 <ItemQuantity>42ml</ItemQuantity>
@@ -983,7 +982,7 @@ class UploadItemsParseOptionalFieldsTestCase(TestCase):
             self.assertIn(code, error)
 
     def test_parse_optional_item_fields_error_frequency(self):
-        xml = f"""
+        xml = """
             <Item>
                 <ItemPackage>1000 TABLETS</ItemPackage>
                 <ItemFrequency>5.55</ItemFrequency>
@@ -1005,7 +1004,7 @@ class UploadItemsParseOptionalFieldsTestCase(TestCase):
             self.assertIn(code, error)
 
     def test_parse_optional_item_fields_error_package_too_small(self):
-        xml = f"""
+        xml = """
             <Item>
                 <ItemPackage> </ItemPackage>
                 <ItemFrequency>1</ItemFrequency>

--- a/tools/tests/_test_upload_services.py
+++ b/tools/tests/_test_upload_services.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 from tempfile import TemporaryFile
 
-from core import filter_validity
 from core.test_helpers import create_test_interactive_user
 from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
@@ -811,7 +810,7 @@ class UploadServicesParseXMLServicesTestCase(TestCase):
 class UploadServicesParseOptionalFieldsTestCase(TestCase):
 
     def test_parse_optional_service_fields_all_empty(self):
-        xml = f"""
+        xml = """
             <Service>
                 <ServiceCategory/>
                 <ServiceFrequency/>
@@ -829,7 +828,7 @@ class UploadServicesParseOptionalFieldsTestCase(TestCase):
             self.assertFalse(error)
 
     def test_parse_optional_service_fields_all_filled(self):
-        xml = f"""
+        xml = """
             <Service>
                 <ServiceCategory>O</ServiceCategory>
                 <ServiceFrequency>5</ServiceFrequency>
@@ -850,7 +849,7 @@ class UploadServicesParseOptionalFieldsTestCase(TestCase):
             self.assertFalse(error)
 
     def test_parse_optional_service_fields_filled_and_empty_frq(self):
-        xml = f"""
+        xml = """
             <Service>
                 <ServiceCategory/>
                 <ServiceFrequency>78</ServiceFrequency>
@@ -871,7 +870,7 @@ class UploadServicesParseOptionalFieldsTestCase(TestCase):
             self.assertFalse(error)
 
     def test_parse_optional_service_fields_filled_and_empty_cat(self):
-        xml = f"""
+        xml = """
             <Service>
                 <ServiceCategory>o</ServiceCategory>
                 <ServiceFrequency/>
@@ -892,7 +891,7 @@ class UploadServicesParseOptionalFieldsTestCase(TestCase):
             self.assertFalse(error)
 
     def test_parse_optional_service_fields_error_frequency(self):
-        xml = f"""
+        xml = """
             <Service>
                 <ServiceCategory>V</ServiceCategory>
                 <ServiceFrequency>5.55</ServiceFrequency>

--- a/tools/tests/test_claims.py
+++ b/tools/tests/test_claims.py
@@ -1,28 +1,22 @@
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import patch, PropertyMock
 
 from django.test import TestCase
 from unittest import mock
 
-from tools.services import upload_claim, InvalidXMLError, get_xml_element, get_xml_element_int,\
+from tools.services import upload_claim, InvalidXMLError, get_xml_element, get_xml_element_int, \
     InvalidXmlInt, create_officer_feedbacks_export, create_officer_renewals_export
 from xml.etree import ElementTree
-from datetime import date, datetime, time, timedelta
+from datetime import date, timedelta
 
-from core.models import Officer
 from core.test_helpers import create_test_officer
 
-from core.utils import filter_validity
-from core.services import create_or_update_officer_villages
-from location.models import Location
 from policy.services import insert_renewals
 from claim.models import Claim
 from claim.services import create_feedback_prompt
 from claim.test_helpers import (
     create_test_claim,
-    create_test_claimservice,
-    create_test_claimitem,
-    delete_claim_with_itemsvc_dedrem_and_history,
 )
+
 
 class UploadClaimsTestCase(TestCase):
     def test_upload_claims_unknown_hf(self):
@@ -50,6 +44,7 @@ class UploadClaimsTestCase(TestCase):
                 "User cannot upload claims for health facility WRONG",
                 str(cm.exception),
             )
+
 
 class GetXmlElement(TestCase):
     def test_get_xml_element(self):
@@ -83,21 +78,22 @@ class register(TestCase):
     test_officer = None
     test_user = None
     claim = None
+
     @classmethod
     def setUpTestData(cls):
-        
+
         cls.claim = create_test_claim(custom_props={'status': Claim.STATUS_CHECKED, 'feedback_status': Claim.FEEDBACK_SELECTED})
-        
-        cls.test_officer = create_test_officer(villages = [cls.claim.insuree.family.location])
-        
+
+        cls.test_officer = create_test_officer(villages=[cls.claim.insuree.family.location])
+
         insert_renewals(
-            date_from= date.today() + timedelta(days=-3650), 
-            date_to=date.today()+ timedelta(days=7300), 
-            officer_id=cls.test_officer.id, 
-            reminding_interval=365, 
-            location_id=cls.claim.insuree.family.location.id, 
+            date_from=date.today() + timedelta(days=-3650),
+            date_to=date.today() + timedelta(days=7300),
+            officer_id=cls.test_officer.id,
+            reminding_interval=365,
+            location_id=cls.claim.insuree.family.location.id,
             location_levels=4)
-        
+
     def test_generating_feedback(self):
         class DummyUser:
             id_for_audit = -1
@@ -105,15 +101,14 @@ class register(TestCase):
         mock_user = mock.Mock(is_anonymous=False)
         mock_user.has_perm = mock.MagicMock(return_value=True)
         mock_user.is_imis_admin = mock.MagicMock(return_value=False)
-        
+
         create_feedback_prompt(self.claim, user=DummyUser())
         zip = create_officer_feedbacks_export(mock_user, self.test_officer)
         self.assertNotEqual(zip, None)
-        
+
     def test_generating_renewal(self):
         mock_user = mock.Mock(is_anonymous=False)
         mock_user.has_perm = mock.MagicMock(return_value=True)
         mock_user.is_imis_admin = mock.MagicMock(return_value=False)
         zip = create_officer_renewals_export(mock_user, self.test_officer)
         self.assertNotEqual(zip, None)
-        

--- a/tools/tests/test_item.py
+++ b/tools/tests/test_item.py
@@ -2,10 +2,9 @@ import os
 from tablib import Dataset
 from core.test_helpers import create_test_interactive_user
 from django.test import TestCase
-from location.test_helpers import create_test_location
-from django.conf import settings
 from medical.test_helpers import create_test_item
 from tools.resources import ItemResource
+
 
 class ImportItemTest(TestCase):
 
@@ -13,6 +12,7 @@ class ImportItemTest(TestCase):
         super(ImportItemTest, self).setUp()
         self.user = create_test_interactive_user()
         create_test_item('S', custom_props={"code": 'SS'})
+
     def test_simple_import(self):
         dir_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
         resource = ItemResource(user=self.user)
@@ -28,4 +28,3 @@ class ImportItemTest(TestCase):
     def test_simple_export(self):
         result = ItemResource(self.user).export().dict
         self.assertTrue(result)
-

--- a/tools/tests/test_rest.py
+++ b/tools/tests/test_rest.py
@@ -2,22 +2,19 @@
 from core.test_helpers import create_test_interactive_user
 from rest_framework import status
 from rest_framework.test import APITestCase
-from dataclasses import dataclass
 from graphql_jwt.shortcuts import get_token
-from core.models import User
 from django.conf import settings
-from django.db import connection
-import json
 import os
 from django.core.files.uploadedfile import SimpleUploadedFile
 from core.models.openimis_graphql_test_case import BaseTestContext as DummyContext
 
 
-class ReportAPITests( APITestCase):
+class ReportAPITests(APITestCase):
 
     admin_user = None
     admin_token = None
     dir_path = None
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -33,14 +30,14 @@ class ReportAPITests( APITestCase):
             uploaded_file = SimpleUploadedFile("service_example.json", file_content, content_type="application/json")
             response = self.client.post(URL, {'file': uploaded_file}, format='multipart', **headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
-              
+
     def test_export_item_xls(self):
         URL = f'/{settings.SITE_ROOT()}tools/exports/items?file_format=xls'
         headers = {"HTTP_AUTHORIZATION": f"Bearer {self.admin_token}"}
         response = self.client.get(URL, format='json', **headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
-        
+
     def test_import_service_json(self):
         URL = f'/{settings.SITE_ROOT()}tools/imports/services?file_format=json'
         headers = {"HTTP_AUTHORIZATION": f"Bearer {self.admin_token}"}
@@ -49,11 +46,28 @@ class ReportAPITests( APITestCase):
             uploaded_file = SimpleUploadedFile("service_example.json", file_content, content_type="application/json")
             response = self.client.post(URL, {'file': uploaded_file}, format='multipart', **headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
-              
+
     def test_export_service_xls(self):
         URL = f'/{settings.SITE_ROOT()}tools/exports/services?file_format=xls'
         headers = {"HTTP_AUTHORIZATION": f"Bearer {self.admin_token}"}
         response = self.client.get(URL, format='json', **headers)
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, getattr(response, "content", "no content"))
+
+    def test_download_master_data(self):
+        URL = f"/{settings.SITE_ROOT()}tools/extracts/download_master_data"
+        headers = {"HTTP_AUTHORIZATION": f"Bearer {self.admin_token}"}
+        response = self.client.get(URL, format="json", **headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, getattr(response, "content", "no content"))
+        # Additional: verify it's a password-protected ZIP
+        import io
+        import pyzipper
+        import tempfile
+        from tools.apps import ToolsConfig
+        zip_data = io.BytesIO(b''.join(response.streaming_content))
+        temp_folder = tempfile.mkdtemp(prefix="offline_archive")
+        with pyzipper.AESZipFile(zip_data, encryption='WZ_AES') as zf:
+            password = ToolsConfig.get_master_data_password() or ")(#$1HsD"
+            zf.setpassword(str.encode(password))
+            zf.extractall(path=temp_folder)
 
 # todo expand tests

--- a/tools/tests/test_service.py
+++ b/tools/tests/test_service.py
@@ -2,14 +2,12 @@ import os
 from tablib import Dataset
 from core.test_helpers import create_test_interactive_user
 from django.test import TestCase
-from location.test_helpers import create_test_location
-from django.conf import settings
 from tools.resources import ServiceResource
 from medical.test_helpers import create_test_service
 
 
 class ImportServiceTest(TestCase):
-    
+
     def setUp(self) -> None:
         super(ImportServiceTest, self).setUp()
         self.user = create_test_interactive_user()
@@ -31,4 +29,3 @@ class ImportServiceTest(TestCase):
     def test_simple_export(self):
         result = ServiceResource(self.user).export().dict
         self.assertTrue(result)
-

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,4 +1,4 @@
-from defusedxml.ElementTree import parse, ParseError
+from defusedxml.ElementTree import parse
 
 
 def dictfetchall(cursor):

--- a/tools/views.py
+++ b/tools/views.py
@@ -5,7 +5,6 @@ import xml.etree.ElementTree as ET
 
 from core.models import Officer
 from core.security import checkUserWithRights
-from core.utils import filter_validity
 from django.core.exceptions import PermissionDenied
 from django.db.models.query_utils import Q
 from django.http import HttpResponse
@@ -28,8 +27,6 @@ from .resources import ItemResource, ServiceResource
 from .services import return_upload_result_json
 
 logger = logging.getLogger(__name__)
-
-
 
 
 @api_view(["GET"])
@@ -161,7 +158,6 @@ def upload_health_facilities(request):
                 "error": str(exc),
             }
         )
-
 
 
 @api_view(["GET"])
@@ -432,6 +428,7 @@ def download_feedbacks(request):
 
     return response
 
+
 @api_view(["GET"])
 def download_renewals(request):
     if not request.user.has_perms(ToolsConfig.extracts_officer_renewals_perms):
@@ -612,7 +609,7 @@ def import_items(request):
     serializer.is_valid(raise_exception=True)
 
     file = serializer.validated_data.get("file")
-    logger.info("User (audit id %s) requested import of medical items",request.user.id_for_audit)
+    logger.info("User (audit id %s) requested import of medical items", request.user.id_for_audit)
 
     item_resource = ItemResource(user=request.user)
     dataset = Dataset()


### PR DESCRIPTION
- Remove unused 'pyminizip' dependency from setup.py
- Comment out unused admin import in tools/admin.py
- Remove unused imports (filter_validity, Prefetch) and comment out logger warning in tools/resources.py and tools/services.py
- Minor formatting and code simplifications in test cases and resource classes
- Simplifies codebase by eliminating dead code and reducing dependencies for better maintainability

#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

remove the problematic zip lib with macbooks


# Type of Change

- [ ] Feature
- [ X] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
