### PR TITLE
fix(test): use real interactive user in test_upload_claims_unknown_hf

### DIFF
--- a/tools/tests/test_claims.py
+++ b/tools/tests/test_claims.py
@@ -9,7 +9,7 @@ from xml.etree import ElementTree
 from datetime import date, datetime, time, timedelta
 
 from core.models import Officer
-from core.test_helpers import create_test_officer
+from core.test_helpers import create_test_officer, create_test_interactive_user
 
 from core.utils import filter_validity
 from core.services import create_or_update_officer_villages
@@ -25,15 +25,17 @@ from claim.test_helpers import (
 )
 
 class UploadClaimsTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.test_user = create_test_interactive_user(username="test_upload_claim_user")
+
     def test_upload_claims_unknown_hf(self):
+        # Mock users fail build_user_location_filter_query's isinstance check and fall through to legacy T-SQL, hanging the DB connection.
         with patch('tools.services.settings.ROW_SECURITY', new_callable=PropertyMock) as row_security_mock:
             row_security_mock.return_value = True
-            mock_user = mock.Mock(is_anonymous=False)
-            mock_user.has_perm = mock.MagicMock(return_value=True)
-            mock_user.is_imis_admin = mock.MagicMock(return_value=False)
             with self.assertRaises(InvalidXMLError) as cm:
                 upload_claim(
-                    mock_user,
+                    self.test_user,
                     ElementTree.fromstring(
                         """
                             <root>


### PR DESCRIPTION
## Summary

- `mock.Mock` fails the `isinstance(user, InteractiveUser)` check in `build_user_location_filter_query`, leaving the HealthFacility queryset unfiltered.
- `upload_claim` then falls through into the legacy T-SQL block (`DECLARE @ret int; EXEC [dbo].[uspUpdateClaimFromPhone]…`), which hangs for ~9 s on PostgreSQL and leaves the connection closed.
- Every subsequent test in the same run fails with `psycopg2.InterfaceError: connection already closed` (~158 cascading errors across modules — observed in openimis-be-payroll_py PR #80 CI).
- Replaced the Mock with `create_test_interactive_user`, so row-security filtering runs and `HFCode="WRONG"` correctly raises `InvalidXMLError` as the test expects.

## Test plan

- [ ] `test_upload_claims_unknown_hf` passes in CI
- [ ] The `Run All Tests (PSQL)` cascade across dependent repos is gone